### PR TITLE
 🌈feat : Container 반응형 css 추가

### DIFF
--- a/src/components/layout/Container.jsx
+++ b/src/components/layout/Container.jsx
@@ -9,5 +9,6 @@ const S = {}
 S.Container = styled.div`
 	position: relative;
 	max-width: 1100px;
-	margin: 0 auto 495px;
+	padding: ${({ theme }) => (theme.isMobile ? '0 16px' : '')};
+	margin: 0 auto ${({ theme }) => (theme.isMobile ? '150px' : '200px')};
 `

--- a/src/components/layout/Container.jsx
+++ b/src/components/layout/Container.jsx
@@ -10,5 +10,5 @@ S.Container = styled.div`
 	position: relative;
 	max-width: 1100px;
 	padding: ${({ theme }) => (theme.isMobile ? '0 16px' : '')};
-	margin: 0 auto ${({ theme }) => (theme.isMobile ? '150px' : '200px')};
+	margin: 0 auto ${({ theme }) => (theme.isMobile ? '100px' : '200px')};
 `


### PR DESCRIPTION
### 요약 (Summary)

- Container 에 반응형 css추가

### 바뀐 점 (Changes)

- margin bottom 값 조절 (pc : 200px, 모바일 : 100px)
- 모바일일 때 양 옆 패딩 16px 추가


### 특이사항 (Optional)

- 모바일일 때 기준은 헤더가 `모바일 헤더`로 변경되는 시점으로 잡았습니다.
- 모바일일때 채팅은 하단 메뉴탭으로 이동하므로 현재 페이지를 가리고 있는 채팅 float 버튼은 안보이게 해야할 것 같습니다!

### Screenshots (Optional)

![image](https://github.com/KIT-Frontend-Team2/Paradise/assets/11881721/c452f212-88ce-4263-a468-21d386c45d73)
