### PR TITLE
 🌈feat : 마이페이지 헤더 api 연결 추가

### DIFF
--- a/src/apis/service/user.api.js
+++ b/src/apis/service/user.api.js
@@ -56,7 +56,7 @@ const userService = {
 	},
 
 	getMypage: () => {
-		return axiosInstance.get(API_KEY.MYPAGE)
+		return axiosInstance.get(API_KEY.API + API_KEY.USER + API_KEY.MYPAGE)
 	},
 
 	changeUserInfo: UserInfo => {

--- a/src/components/templates/MyPageTemplate/MyPageTemplateSkeleton.jsx
+++ b/src/components/templates/MyPageTemplate/MyPageTemplateSkeleton.jsx
@@ -1,0 +1,86 @@
+import Container from 'components/layout/Container'
+import MSkeleton from 'components/ui/atoms/Skeleton/MSkeleton'
+import { styled } from 'styled-components'
+
+const MyPageTemplateSkeleton = () => {
+	return (
+		<>
+			<S.LoadingHeader>
+				<MSkeleton height={180} variant={'rectangular'} />
+			</S.LoadingHeader>
+			<Container>
+				<S.Wrapper>
+					<S.MyMenu>
+						<S.MyTitle>
+							<MSkeleton height={38} variant={'rectangular'} />
+						</S.MyTitle>
+						<ul>
+							<li></li>
+							<li></li>
+							<li></li>
+							<li></li>
+							<li></li>
+						</ul>
+					</S.MyMenu>
+					<S.ContentWrap>
+						<MSkeleton height={500} variant={'rectangular'} />
+					</S.ContentWrap>
+				</S.Wrapper>
+			</Container>
+		</>
+	)
+}
+
+export default MyPageTemplateSkeleton
+
+const S = {}
+
+S.LoadingHeader = styled.div`
+	margin-bottom: 30px;
+`
+
+S.Container = styled.div`
+	min-height: 100vh;
+`
+
+S.Wrapper = styled.div`
+	display: flex;
+	flex-direction: ${({ theme }) => (theme.isDesktop ? 'row' : 'column')};
+	gap: 50px;
+	min-height: 100vh;
+`
+
+S.MyMenu = styled.div`
+	width: ${({ theme }) => (theme.isDesktop ? '174px' : '100%')};
+
+	ul {
+		margin: 0;
+		padding: 0;
+		border: 1px solid ${({ theme }) => theme.PALETTE.gray[400]};
+		display: flex;
+		flex-direction: column;
+		justify-content: space-between;
+		flex: 1;
+	}
+
+	li {
+		position: relative;
+		list-style: none;
+		height: 50px;
+		padding: ${({ theme }) => (theme.isDesktop ? '25px' : '20px')};
+		border-top: 1px solid ${({ theme }) => theme.PALETTE.gray[400]};
+		flex: 1;
+		&:first-child {
+			border-top: 0;
+		}
+	}
+`
+
+S.MyTitle = styled.div`
+	margin-bottom: 30px;
+	display: ${({ theme }) => (theme.isDesktop ? 'block' : 'none')};
+`
+
+S.ContentWrap = styled.div`
+	flex: 1;
+`

--- a/src/components/ui/organisms/MyHeader/MyHeader.jsx
+++ b/src/components/ui/organisms/MyHeader/MyHeader.jsx
@@ -8,25 +8,14 @@ const MyHeader = () => {
 	const [myMenu, setMyMenu] = useRecoilState(myMenuAtom)
 
 	const { getMyPageHeader } = LoadUserApi()
-	const { data, isLoading, isError } = getMyPageHeader()
+	const { data } = getMyPageHeader()
 
-	if (isError) {
-		return <>Error</>
-	}
+	console.log(data.data)
 
-	if (isLoading) {
-		return <S.LoadingHeader></S.LoadingHeader>
-	}
+	const { User, ondo, productsCount, likeCount, chatCount } = data.data
+	const { nickName, profileUrl } = User
 
-	const {
-		user_nick_name,
-		user_profile_url,
-		user_temperature,
-		user_address,
-		user_total_product,
-		user_like_list_count,
-		user_chat_count,
-	} = data.data.data.user_info
+	const user_address = '서울시 강남구 역삼동'
 
 	const onClickMenu = path => {
 		setMyMenu(path)
@@ -40,12 +29,12 @@ const MyHeader = () => {
 						<S.EditButton>
 							<EditIcon sx={{ color: '#333' }} />
 						</S.EditButton>
-						<img src={user_profile_url} alt={user_nick_name} loading={'lazy'} />
+						<img src={profileUrl || ''} alt={nickName} loading={'lazy'} />
 					</S.UserImg>
 					<div>
 						<S.FlexWrap>
-							<S.UserNick>{user_nick_name}</S.UserNick>
-							<S.UserOndo>{user_temperature}℃</S.UserOndo>
+							<S.UserNick>{nickName}</S.UserNick>
+							<S.UserOndo>{ondo}℃</S.UserOndo>
 						</S.FlexWrap>
 						<S.UserAddress>{user_address}</S.UserAddress>
 					</div>
@@ -57,7 +46,7 @@ const MyHeader = () => {
 							className={myMenu === 'mySell' ? 'on' : ''}
 							onClick={() => onClickMenu('mySell')}
 						>
-							{user_total_product}
+							{productsCount}
 						</S.Link>
 					</S.Box>
 					<S.Box>
@@ -66,7 +55,7 @@ const MyHeader = () => {
 							className={myMenu === 'wish' ? 'on' : ''}
 							onClick={() => onClickMenu('wish')}
 						>
-							{user_like_list_count}
+							{likeCount}
 						</S.Link>
 					</S.Box>
 					<S.Box>
@@ -75,7 +64,7 @@ const MyHeader = () => {
 							className={myMenu === 'chat' ? 'on' : ''}
 							onClick={() => window.alert('채팅 오픈')}
 						>
-							{user_chat_count}
+							{chatCount}
 						</S.Link>
 					</S.Box>
 				</S.BoxContainer>
@@ -90,12 +79,6 @@ const S = {}
 
 S.Header = styled.div`
 	background-color: ${({ theme }) => theme.PALETTE.gray[100]};
-	margin-bottom: 30px;
-`
-
-S.LoadingHeader = styled.div`
-	background-color: ${({ theme }) => theme.PALETTE.gray[100]};
-	height: 180px;
 	margin-bottom: 30px;
 `
 

--- a/src/consts/ApiKey.js
+++ b/src/consts/ApiKey.js
@@ -8,7 +8,7 @@ const API_KEY = {
 	SHARE: '/share',
 	DETAIL: '/detail',
 	SEARCH: '/search',
-	MYPAGE: '/mypage',
+	MYPAGE: '/my-page',
 	LIKE: '/like',
 	ACCOUNT: '/account',
 	PROFILE: '/profile',

--- a/src/hooks/pageQuery/useLoadUser.js
+++ b/src/hooks/pageQuery/useLoadUser.js
@@ -5,16 +5,12 @@ import { useQuery } from 'react-query'
 import { queryConfig } from './@config'
 
 const LoadUserApi = () => {
-	const { getMyPage } = userService()
-
 	const getMyPageHeader = () => {
-		const { data, isLoading, isError } = useQuery(
-			[API_KEY.MYPAGE],
-			() => getMyPage(),
-			{ ...queryConfig },
-		)
+		const { data } = useQuery([API_KEY.MYPAGE], () => userService.getMypage(), {
+			...queryConfig,
+		})
 
-		return { data, isLoading, isError }
+		return { data }
 	}
 
 	return { getMyPageHeader }

--- a/src/routes/router.jsx
+++ b/src/routes/router.jsx
@@ -1,4 +1,5 @@
 import Container from 'components/layout/Container'
+import MyPageTemplateSkeleton from 'components/templates/MyPageTemplate/MyPageTemplateSkeleton'
 import { Suspense } from 'react'
 import { createBrowserRouter } from 'react-router-dom'
 
@@ -92,11 +93,10 @@ const router = createBrowserRouter([
 							</Suspense>
 						),
 					},
-
 					{
 						path: API_KEY.MYPAGE,
 						element: (
-							<Suspense>
+							<Suspense fallback={<MyPageTemplateSkeleton />}>
 								<MyPage />
 							</Suspense>
 						),


### PR DESCRIPTION
### 요약 (Summary)

- 마이페이지 헤더에 api 연결 추가

### 바뀐 점 (Changes)

- 마이페이지 메인 api 연결

### 특이사항 (Optional)

- 이전에 msw 기준으로 연결되어 있다보니 마이페이지 진입 시 에러가 나고 있어 마이페이지 메인을 우선적으로 작업했습니다.
- api 주소에 연결하다보니 마이페이지 경로가 `/my-page`로 바꼈습니다.
- 마이페이지에 스켈레톤 UI를 추가했습니다.
- 추가 요청할 데이터를 [노션](https://www.notion.so/koreait-front-team2/API-d0dfdd121d564562bf55057e9253dcd4?pvs=4#c266ed2bbcd7441583179f3d83af8b36) 에 정리했습니다.

### Screenshots (Optional)

![image](https://github.com/KIT-Frontend-Team2/Paradise/assets/11881721/d5f2c205-d8f7-4885-95c1-0dab3abd4858)
