### PR TITLE
 📝fix : 헤더 카테고리에 ,가 하나 더 들어가있어서 카테고리 배열에 empty값이 들어가는 현상 수정

### DIFF
--- a/src/components/ui/organisms/MainHeader/HeaderCategory.jsx
+++ b/src/components/ui/organisms/MainHeader/HeaderCategory.jsx
@@ -68,7 +68,6 @@ export const categories = [
 		label: '가공식품',
 		path: 'processed-food',
 	},
-	,
 	{
 		label: '반려동물용품',
 		path: 'animal',


### PR DESCRIPTION
### 요약 (Summary)

- 헤더 카테고리 수정

### 바뀐 점 (Changes)

- 헤더 카테고리에 ,가 하나 더 들어가있어서 카테고리 배열에 empty값이 들어가는 현상  수정


### 특이사항 (Optional)

- 현재 헤더에서는 오류 없으나 물품 등록 시 카테고리를 비교하는 부분에서 오류가 발생하여 수정했습니다.
