### PR TITLE
🌈feat : toast message 추가

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
         "react-daum-postcode": "^3.1.3",
         "react-dom": "^18.2.0",
         "react-hook-form": "^7.45.2",
+        "react-hot-toast": "^2.4.1",
         "react-icons": "^4.10.1",
         "react-query": "^3.39.3",
         "react-router-dom": "^6.14.1",
@@ -14840,6 +14841,14 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/goober": {
+      "version": "2.1.13",
+      "resolved": "https://registry.npmjs.org/goober/-/goober-2.1.13.tgz",
+      "integrity": "sha512-jFj3BQeleOoy7t93E9rZ2de+ScC4lQICLwiAQmKMg9F6roKGaLSHoCDYKkWlSafg138jejvq/mTdvmnwDQgqoQ==",
+      "peerDependencies": {
+        "csstype": "^3.0.10"
+      }
+    },
     "node_modules/gopd": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz",
@@ -21748,6 +21757,21 @@
       },
       "peerDependencies": {
         "react": "^16.8.0 || ^17 || ^18"
+      }
+    },
+    "node_modules/react-hot-toast": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/react-hot-toast/-/react-hot-toast-2.4.1.tgz",
+      "integrity": "sha512-j8z+cQbWIM5LY37pR6uZR6D4LfseplqnuAO4co4u8917hBUvXlEqyP1ZzqVLcqoyUesZZv/ImreoCeHVDpE5pQ==",
+      "dependencies": {
+        "goober": "^2.1.10"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "react": ">=16",
+        "react-dom": ">=16"
       }
     },
     "node_modules/react-icons": {
@@ -36461,6 +36485,12 @@
         "slash": "^3.0.0"
       }
     },
+    "goober": {
+      "version": "2.1.13",
+      "resolved": "https://registry.npmjs.org/goober/-/goober-2.1.13.tgz",
+      "integrity": "sha512-jFj3BQeleOoy7t93E9rZ2de+ScC4lQICLwiAQmKMg9F6roKGaLSHoCDYKkWlSafg138jejvq/mTdvmnwDQgqoQ==",
+      "requires": {}
+    },
     "gopd": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz",
@@ -41471,6 +41501,14 @@
       "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.45.2.tgz",
       "integrity": "sha512-9s45OdTaKN+4NSTbXVqeDITd/nwIg++nxJGL8+OD5uf1DxvhsXQ641kaYHk5K28cpIOTYm71O/fYk7rFaygb3A==",
       "requires": {}
+    },
+    "react-hot-toast": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/react-hot-toast/-/react-hot-toast-2.4.1.tgz",
+      "integrity": "sha512-j8z+cQbWIM5LY37pR6uZR6D4LfseplqnuAO4co4u8917hBUvXlEqyP1ZzqVLcqoyUesZZv/ImreoCeHVDpE5pQ==",
+      "requires": {
+        "goober": "^2.1.10"
+      }
     },
     "react-icons": {
       "version": "4.10.1",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "react-daum-postcode": "^3.1.3",
     "react-dom": "^18.2.0",
     "react-hook-form": "^7.45.2",
+    "react-hot-toast": "^2.4.1",
     "react-icons": "^4.10.1",
     "react-query": "^3.39.3",
     "react-router-dom": "^6.14.1",

--- a/src/components/layout/MainLayout.jsx
+++ b/src/components/layout/MainLayout.jsx
@@ -8,12 +8,17 @@ import ErrorBoundary from '../error/ErrorBoundary'
 import SideBar from '../modal/Side/SideBar'
 import MainFooter from '../ui/organisms/MainFooter/MainFooter'
 import MainHeader from '../ui/organisms/MainHeader/MainHeader'
+import {Toaster} from "react-hot-toast";
 
 const MainLayout = () => {
 	const { handleErrorReset } = useResetError()
 
 	return (
 		<ErrorBoundary Fallback={ErrorPage} onReset={handleErrorReset}>
+			<Toaster
+				position="top-center"
+				reverseOrder={false}
+			/>
 			<S.Wrapper>
 				<Suspense fallback={<></>}>
 					<SideBar />

--- a/src/components/modal/Review/Review.jsx
+++ b/src/components/modal/Review/Review.jsx
@@ -9,8 +9,10 @@ import React, { useEffect, useRef, useState } from 'react'
 import { useForm } from 'react-hook-form'
 import styled from 'styled-components'
 
+import { REVIEW_MESSAGE } from '../../../consts/message'
 import { Product_Info } from '../../../consts/product'
 import reviewService from '../../../hooks/service/review.service'
+import toastMessage from '../../../utils/toast-message'
 
 const Review = ({ page, isUpdate, detail, handleClose, ReviewId }) => {
 	const { img_url, ReviewImages, title, content, ondo, idx } = (isUpdate &&
@@ -62,7 +64,7 @@ const Review = ({ page, isUpdate, detail, handleClose, ReviewId }) => {
 
 				if (mainImage) totalImageCnt++
 				if (totalImageCnt > 5) {
-					return alert('이미지는 최대 5장까지 등록 가능합니다.')
+					return toastMessage.error(REVIEW_MESSAGE.IMAGE_MAX_ERROR)
 				}
 				setImagePreviews([...imagePreviewsArray])
 				setImageFileList([...imageFileArray])
@@ -83,29 +85,38 @@ const Review = ({ page, isUpdate, detail, handleClose, ReviewId }) => {
 				formData.append('images', el)
 			})
 		}
-		const mode = isUpdate && detail ? '수정' : '등록'
 
-		if (confirm(`리뷰를 ${mode}하시겠습니까?`)) {
-			if (isUpdate && detail) {
-				if (mainImage) {
-					formData.append('main_url', mainImage)
-				}
-				formData.append('img_url', subImageList)
-				console.log(imageFileList)
-				console.log(imageFileList)
-				const response = await patchMutate({ idx, formData })
-				if (response.status === 200) {
-					window.alert(`리뷰 ${mode}이 완료되었습니다.`)
-					handleClose()
-				}
-				// 수정
-			} else {
-				// 등록
-				const response = await postMutate({ ReviewId, formData })
-				if (response.status === 200) {
-					window.alert(`리뷰 ${mode}이 완료되었습니다.`)
-					handleClose()
-				}
+		if (isUpdate && detail) {
+			if (mainImage) {
+				formData.append('main_url', mainImage)
+			}
+			formData.append('img_url', subImageList)
+			const response = await toastMessage.promise(
+				patchMutate({
+					idx,
+					formData,
+				}),
+				REVIEW_MESSAGE.PATCH_LOADING,
+				REVIEW_MESSAGE.PATCH_SUCCESS,
+				REVIEW_MESSAGE.ERROR_MESSAGE,
+			)
+			if (response.status === 200) {
+				handleClose()
+			}
+			// 수정
+		} else {
+			// 등록
+			const response = await toastMessage.promise(
+				postMutate({
+					ReviewId,
+					formData,
+				}),
+				REVIEW_MESSAGE.POST_LOADING,
+				REVIEW_MESSAGE.POST_SUCCESS,
+				REVIEW_MESSAGE.ERROR_MESSAGE,
+			)
+			if (response.status === 200) {
+				handleClose()
 			}
 		}
 	}
@@ -264,7 +275,7 @@ export const S = {}
 
 S.BackgroundColor = styled.div`
 	background: white;
-	padding: 20px 20px 20px;
+	padding: 50px;
 `
 
 S.Con = styled.div`

--- a/src/components/templates/MyPageTemplate/MyReviewTemplate.jsx
+++ b/src/components/templates/MyPageTemplate/MyReviewTemplate.jsx
@@ -3,8 +3,10 @@ import React, { Suspense, useState } from 'react'
 import { useSearchParams } from 'react-router-dom'
 import { styled } from 'styled-components'
 
+import { REVIEW_MESSAGE } from '../../../consts/message'
 import { useDevice } from '../../../hooks/mediaQuery/useDevice'
 import reviewService from '../../../hooks/service/review.service'
+import ToastMessage from '../../../utils/toast-message'
 import Review from '../../modal/Review/Review'
 import ReviewDetail from '../../modal/Review/ReviewDetail'
 import Button from '../../ui/atoms/Button/Button'
@@ -63,14 +65,15 @@ const MyReviewTemplate = () => {
 	}
 
 	const deletehandling = async id => {
-		try {
-			if (confirm('정말 삭제하시겠습니까?')) {
-				await deleteMutate(id)
-				detailClose()
-				setSelectState(false)
-			}
-		} catch (err) {
-			console.log(err)
+		if (confirm('정말 삭제하시겠습니까?')) {
+			await ToastMessage.promise(
+				deleteMutate(id),
+				REVIEW_MESSAGE.DELETE_LOADING,
+				REVIEW_MESSAGE.DELETE_SUCCESS,
+				REVIEW_MESSAGE.ERROR_MESSAGE,
+			)
+			detailClose()
+			setSelectState(false)
 		}
 	}
 
@@ -105,7 +108,7 @@ const MyReviewTemplate = () => {
 			{/*리뷰 작성, 수정하기 모달*/}
 			<Modal
 				open={isOpen}
-				onClose={updateClose}
+				onClose={() => updateClose()}
 				children={
 					<S.ModalContainer mobile={isMobile.toString()}>
 						<Review
@@ -121,7 +124,7 @@ const MyReviewTemplate = () => {
 			{/*리뷰 상세 모달*/}
 			<Modal
 				open={isDetail}
-				onClose={detailClose}
+				onClose={() => detailClose()}
 				children={
 					<Suspense fallback={<></>}>
 						<S.ModalContainer mobile={isMobile.toString()}>

--- a/src/consts/message.js
+++ b/src/consts/message.js
@@ -2,3 +2,15 @@ export const EMPTY_MESSAGE = {
 	EMPTY_LIST: '등록된 상품이 없어요',
 	EMPTY_RELATED: '관련된 상품이 없어요',
 }
+
+export const REVIEW_MESSAGE = {
+	IMAGE_REPLACE_ERROR: '기존 이미지의 순서 변경을 불가능합니다.',
+	IMAGE_MAX_ERROR: '이미지는 최대 5장까지 등록이 가능합니다.',
+	ERROR_MESSAGE: '오류가 발생하였습니다.',
+	POST_SUCCESS: '등록 되었습니다.',
+	DELETE_SUCCESS: '삭제 되었습니다.',
+	PATCH_SUCCESS: '수정 되었습니다.',
+	POST_LOADING: '등록중입니다.',
+	PATCH_LOADING: '수정중입니다.',
+	DELETE_LOADING: '삭제중입니다.',
+}

--- a/src/hooks/service/review.service.js
+++ b/src/hooks/service/review.service.js
@@ -4,8 +4,6 @@ import { queryClient } from '../../App'
 import reviewApi from '../../apis/service/review.api'
 import API_KEY from '../../consts/ApiKey'
 
-// import {queryClient} from "../../App";
-
 const reviewService = {
 	postReview: page => {
 		const { mutateAsync: postMutate } = useMutation(
@@ -48,7 +46,6 @@ const reviewService = {
 		const { mutateAsync: deleteMutate } = useMutation(
 			review_idx => reviewApi.deleteReview(review_idx),
 			{
-				onSuccess: () => alert('삭제되었습니다.'),
 				onSettled: () =>
 					queryClient.invalidateQueries([API_KEY.REVIEW, API_KEY.LIST, page]),
 			},

--- a/src/utils/toast-message.js
+++ b/src/utils/toast-message.js
@@ -1,0 +1,14 @@
+import toast from 'react-hot-toast'
+
+const toastMessage = {
+	success: message => toast.success(message),
+	error: message => toast.error(message),
+	promise: (promiseFn, loading, success, error) =>
+		toast.promise(promiseFn, {
+			loading,
+			success,
+			error,
+		}),
+}
+
+export default toastMessage


### PR DESCRIPTION
### 요약 (Summary)

- 🌈feat : toast message 추가완료

### 바뀐 점 (Changes)

-  toast message를 추가하였습니다.


### 사용방법 (Optional)

- consts 폴더에 상수로 해당 메세지를 정의해둡니다.
- toastMessage를 불러와서 사용하면 됩니다.
- success, error의 경우 해당 메세지를 전달하면 바로 실행이 됩니다.
- promise의 경우 첫번째 인자로 프로미스 값을 2, 3, 4 인자로 각각 로딩, 성공, 실패 메세지를 전달합니다.

### Screenshots (Optional)

- 
![image](https://github.com/KIT-Frontend-Team2/Paradise/assets/115636461/0da08673-e040-42ce-9822-bc68ef33a80e)
