### PR TITLE
🌈feat : 물품 등록 시 배경 제거 기능 추가

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@emotion/react": "^11.11.1",
         "@emotion/styled": "^11.11.0",
         "@hookform/resolvers": "^3.1.1",
+        "@imgly/background-removal": "^1.0.6",
         "@mdx-js/react": "^2.3.0",
         "@mui/icons-material": "^5.14.0",
         "@mui/material": "^5.14.0",
@@ -3356,6 +3357,11 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz",
       "integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA=="
+    },
+    "node_modules/@imgly/background-removal": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/@imgly/background-removal/-/background-removal-1.0.6.tgz",
+      "integrity": "sha512-ExO82TiTj0HTEMsTUCQ6krCbZxgr5ao2G5ktizD3YpeRxiHMEZeH7AWDDho8mNcw8kgtjF9geHLAhiW9CQ8dUA=="
     },
     "node_modules/@istanbuljs/load-nyc-config": {
       "version": "1.1.0",
@@ -28126,6 +28132,11 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz",
       "integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA=="
+    },
+    "@imgly/background-removal": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/@imgly/background-removal/-/background-removal-1.0.6.tgz",
+      "integrity": "sha512-ExO82TiTj0HTEMsTUCQ6krCbZxgr5ao2G5ktizD3YpeRxiHMEZeH7AWDDho8mNcw8kgtjF9geHLAhiW9CQ8dUA=="
     },
     "@istanbuljs/load-nyc-config": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "@emotion/react": "^11.11.1",
     "@emotion/styled": "^11.11.0",
     "@hookform/resolvers": "^3.1.1",
+    "@imgly/background-removal": "^1.0.6",
     "@mdx-js/react": "^2.3.0",
     "@mui/icons-material": "^5.14.0",
     "@mui/material": "^5.14.0",

--- a/src/components/modal/Review/Review.jsx
+++ b/src/components/modal/Review/Review.jsx
@@ -236,12 +236,9 @@ const Review = ({ page, isUpdate, detail, handleClose, ReviewId }) => {
 											setImagePreviews={setImagePreviews}
 											imageFileList={imageFileList}
 											setImageFileList={setImageFileList}
+											type={'review'}
 										/>
 									</div>
-									<ul className="infoMessage">
-										<li>클릭 또는 이미지를 드래그하여 등록할 수 있습니다.</li>
-										<li>드래그하여 상품 이미지 순서를 변경할 수 있습니다.</li>
-									</ul>
 								</S.FormRegister>
 							</S.FormGroup>
 							{/* 버튼 그룹 시작 */}

--- a/src/components/pages/ProductRegisterPage.jsx
+++ b/src/components/pages/ProductRegisterPage.jsx
@@ -1,10 +1,12 @@
 import ProductForm from 'components/templates/ProductFormTemplate/ProductForm'
-import React from 'react'
+import useMypageApi from 'hooks/service/useMypage.service'
 
 const ProductRegisterPage = () => {
+	const { data: userInfo } = useMypageApi.useGetinfo() // 판매자 지역 정보
+
 	return (
 		<>
-			<ProductForm />
+			<ProductForm userInfo={userInfo.data} />
 		</>
 	)
 }

--- a/src/components/templates/ProductFormTemplate/ProductForm.jsx
+++ b/src/components/templates/ProductFormTemplate/ProductForm.jsx
@@ -48,6 +48,7 @@ const ProductForm = ({ isSeller, detail }) => {
 	const [tagList, setTagList] = useState([])
 	const [address, setAddress] = useState(region)
 	const [koPrice, setKoPrice] = useState('')
+	const [removeBgUrl, setRemoveBgUrl] = useState(null)
 
 	const imageRef = useRef()
 	const categoryRef = useRef()
@@ -292,15 +293,35 @@ const ProductForm = ({ isSeller, detail }) => {
 			}
 		}
 
+		const convertImage = async () => {
+			for (let index = 0; index < imageFileList.length; index++) {
+				const el = imageFileList[index]
+
+				if (index === 0 && !detail) {
+					try {
+						const response = await fetch(removeBgUrl)
+						const blob = await response.blob()
+
+						const bgRemoveFile = new File([blob], 'image.jpg', {
+							type: blob.type,
+						})
+						formData.append('images', bgRemoveFile)
+					} catch (err) {
+						console.error('이미지 가져오기 실패', err)
+					}
+				} else {
+					formData.append('images', el)
+				}
+			}
+		}
+
 		formData.append('title', data.title)
 		formData.append('price', data.price)
 		formData.append('description', data.description)
 		formData.append('category', data.category)
 		formData.append('region', data.region)
 		formData.append('tag', data.tag)
-		imageFileList.forEach(el => {
-			formData.append('images', el)
-		})
+		await convertImage()
 
 		const mode = detail ? '수정' : '등록'
 
@@ -378,6 +399,7 @@ const ProductForm = ({ isSeller, detail }) => {
 								<S.FormRegister>
 									<div>
 										<DeFormImagePreviewGroup
+											detail={detail}
 											ref={imageRef}
 											register={register}
 											handleImageChange={handleImageChange}
@@ -389,12 +411,10 @@ const ProductForm = ({ isSeller, detail }) => {
 											setImagePreviews={setImagePreviews}
 											imageFileList={imageFileList}
 											setImageFileList={setImageFileList}
+											removeBgUrl={removeBgUrl}
+											setRemoveBgUrl={setRemoveBgUrl}
 										/>
 									</div>
-									<ul className="infoMessage">
-										<li>클릭 또는 이미지를 드래그하여 등록할 수 있습니다.</li>
-										<li>드래그하여 상품 이미지 순서를 변경할 수 있습니다.</li>
-									</ul>
 									{errors.image && (
 										<S.ErrorMessage className="error">
 											{errors.image.message}

--- a/src/components/templates/ProductFormTemplate/ProductForm.jsx
+++ b/src/components/templates/ProductFormTemplate/ProductForm.jsx
@@ -519,7 +519,7 @@ const ProductForm = ({ userInfo, isSeller, detail }) => {
 													ref={tagRef}
 													className="tag"
 													placeholder={'태그를 입력해주세요'}
-													width={isDesk && '348'}
+													width={isDesk ? '348' : ''}
 													onKeyPress={onTagEnter}
 												/>
 											</S.CustomInput>

--- a/src/components/templates/ProductFormTemplate/ProductForm.jsx
+++ b/src/components/templates/ProductFormTemplate/ProductForm.jsx
@@ -51,7 +51,6 @@ const ProductForm = ({ isSeller, detail }) => {
 	const [removeBgUrl, setRemoveBgUrl] = useState(null)
 
 	const imageRef = useRef()
-	const categoryRef = useRef()
 	const tagRef = useRef()
 	const addressRef = useRef()
 
@@ -485,11 +484,12 @@ const ProductForm = ({ isSeller, detail }) => {
 								<S.FormRegister>
 									<S.TagWrapper>
 										<FormControl>
-											<InputLabel id="tag">카테고리</InputLabel>
+											<InputLabel id="category-tag-label">카테고리</InputLabel>
 											<Select
-												ref={categoryRef}
-												labelId="tag"
-												value={categoryTag}
+												name="categoryTag"
+												labelId="category-tag-label"
+												label="카테고리"
+												value={categoryTag ? categoryTag : ''}
 												sx={{
 													width: isDesk ? '200px' : '100%',
 													height: '50px',

--- a/src/components/templates/ProductFormTemplate/ProductForm.jsx
+++ b/src/components/templates/ProductFormTemplate/ProductForm.jsx
@@ -17,7 +17,7 @@ import { formatNumberToMoney, moneyToFormatNumber } from 'utils/formatter'
 import * as S from './style'
 import * as V from './validator'
 
-const ProductForm = ({ isSeller, detail }) => {
+const ProductForm = ({ userInfo, isSeller, detail }) => {
 	const {
 		idx,
 		title,
@@ -34,7 +34,7 @@ const ProductForm = ({ isSeller, detail }) => {
 		images: [],
 		ProductsTags: [],
 		ProductImages: [],
-		region: '서울시 강남구 역삼동', // 작성자 지역
+		region: '', // 작성자 지역
 	}
 
 	const MAX_IMAGE_CNT = 5
@@ -61,7 +61,10 @@ const ProductForm = ({ isSeller, detail }) => {
 		const images = ProductImages.map(ProductImage => ProductImage.img_url)
 		setSubImageList(images)
 		price && geKoreanNumber(price)
-	}, [detail])
+		if (userInfo) {
+			setAddress(userInfo.region)
+		}
+	}, [detail, userInfo])
 
 	const { linkMainPage, linkDetailPage } = useMove()
 
@@ -132,7 +135,7 @@ const ProductForm = ({ isSeller, detail }) => {
 			category: category ? 1 : 0,
 			price: formatNumberToMoney(price),
 			description: description,
-			region: region,
+			region: address,
 		},
 	})
 
@@ -301,7 +304,7 @@ const ProductForm = ({ isSeller, detail }) => {
 						const response = await fetch(removeBgUrl)
 						const blob = await response.blob()
 
-						const bgRemoveFile = new File([blob], 'image.jpg', {
+						const bgRemoveFile = new File([blob], 'image.png', {
 							type: blob.type,
 						})
 						formData.append('images', bgRemoveFile)

--- a/src/components/templates/ProductFormTemplate/style.js
+++ b/src/components/templates/ProductFormTemplate/style.js
@@ -115,9 +115,11 @@ export const CustomInput = styled.div`
 
 	&.price {
 		display: flex;
-		flex-direction: ${({ theme }) => (theme.isDesktop ? 'row' : 'column')};
+		flex-direction: ${({ theme }) =>
+			theme.isDesktop || theme.isTabletAndLaptop ? 'row' : 'column'};
 		gap: 20px;
-		align-items: ${({ theme }) => (theme.isDesktop ? 'center' : 'flex-end')};
+		align-items: ${({ theme }) =>
+			theme.isDesktop || theme.isTabletAndLaptop ? 'center' : 'flex-end'};
 
 		input {
 			text-align: right;

--- a/src/components/ui/organisms/DeFormImagePreviewGroup/DeFormImagePreviewGroup.jsx
+++ b/src/components/ui/organisms/DeFormImagePreviewGroup/DeFormImagePreviewGroup.jsx
@@ -136,7 +136,7 @@ const DeFormImagePreviewGroup = forwardRef(
 		return (
 			<>
 				<S.PreviewGroup>
-					<S.ToastMessageWrap isModalOpen={isModalOpen}>
+					<S.ToastMessageWrap ismodalopen={isModalOpen.toString()}>
 						<S.ToastMessage>
 							기존에 등록된 이미지는 순서 변경이 불가능합니다. <br />
 							순서 변경을 원하시면 이미지를 다시 등록해주세요.
@@ -396,7 +396,7 @@ S.DeleteButton = styled.div`
 `
 
 S.ToastMessageWrap = styled.div`
-	display: ${({ isModalOpen }) => (isModalOpen ? 'flex' : 'none')};
+	display: ${({ ismodalopen }) => (ismodalopen === 'true' ? 'flex' : 'none')};
 	position: absolute;
 	top: ${({ theme }) =>
 		theme.isDesktop || theme.isTabletAndLaptop ? '-30px' : '10em'};

--- a/src/components/ui/organisms/DeFormImagePreviewGroup/DeFormImagePreviewGroup.jsx
+++ b/src/components/ui/organisms/DeFormImagePreviewGroup/DeFormImagePreviewGroup.jsx
@@ -1,5 +1,7 @@
+import removeBackground from '@imgly/background-removal'
 import registerIcon from 'assets/images/ico-image-register.png'
 import deleteIcon from 'assets/images/ico-preview-del.png'
+import Button from 'components/ui/atoms/Button/Button'
 import { useDevice } from 'hooks/mediaQuery/useDevice'
 import { forwardRef, useEffect, useState } from 'react'
 import { DragDropContext, Draggable, Droppable } from 'react-beautiful-dnd'
@@ -8,6 +10,7 @@ import { styled } from 'styled-components'
 const DeFormImagePreviewGroup = forwardRef(
 	(
 		{
+			detail,
 			register,
 			handleImageChange,
 			mainImage,
@@ -18,12 +21,15 @@ const DeFormImagePreviewGroup = forwardRef(
 			setImagePreviews,
 			imageFileList,
 			setImageFileList,
+			removeBgUrl,
+			setRemoveBgUrl,
 		},
 		ref,
 	) => {
 		const [isHighlight, setIsHighlight] = useState(false)
 		const [isModalOpen, setIsModalOpen] = useState(false)
-
+		const [isRemoveBgLoading, setIsRemoveBgLoading] = useState(false)
+		const [isRemoveDone, setIsRemoveDone] = useState(false)
 		const { isDesktop, isTabletAndLaptop } = useDevice()
 
 		const isDesk = isDesktop || isTabletAndLaptop
@@ -106,110 +112,163 @@ const DeFormImagePreviewGroup = forwardRef(
 			}
 		}, [isModalOpen])
 
+		const removeBg = async () => {
+			setIsRemoveBgLoading(true)
+
+			const image = removeBgUrl
+			const imageBlob = await removeBackground(image)
+			const url = URL.createObjectURL(imageBlob)
+
+			setRemoveBgUrl(url)
+			setIsRemoveBgLoading(false)
+			setIsRemoveDone(true)
+		}
+
+		// 썸네일 미리보기
+		useEffect(() => {
+			if (!detail && imagePreviews.length > 0) {
+				setRemoveBgUrl(imagePreviews[0].img_url)
+				setIsRemoveDone(false)
+			} else {
+				setRemoveBgUrl(null)
+			}
+		}, [imagePreviews[0]])
 		return (
-			<S.PreviewGroup>
-				<S.ToastMessageWrap isModalOpen={isModalOpen}>
-					<S.ToastMessage>
-						기존에 등록된 이미지는 순서 변경이 불가능합니다. <br />
-						순서 변경을 원하시면 이미지를 다시 등록해주세요.
-					</S.ToastMessage>
-				</S.ToastMessageWrap>
-				<input
-					type="file"
-					name="file"
-					id="file"
-					accept="image/*"
-					multiple
-					onChange={event => handleImageChange(event.target.files)}
-				/>
-				<label
-					htmlFor="file"
-					role="button"
-					className={isHighlight ? 'highlight' : ''}
-					onDragEnter={highlight}
-					onDragOver={highlight}
-					onDragLeave={unhighlight}
-					onDrop={handleDrop}
-				>
-					<img className="registerIcon" src={registerIcon} ref={ref} />
-				</label>
-				{mainImage && (
-					<>
-						{!isDesk && <p>기존 이미지 (순서 변경 불가)</p>}
-						<div className="previewBoxWrap">
-							{mainImage && (
-								<div className="previewBox" onDragEnter={alertDragDisable}>
-									<img src={mainImage} alt="메인이미지" />
-									<S.DeleteButton onClick={onDeleteMainImage}>
-										<img src={deleteIcon} />
-									</S.DeleteButton>
-								</div>
-							)}
-							{subImageList.length > 0 &&
-								subImageList.map((preview, index) => (
-									<div
-										key={`img-${index}`}
-										className="previewBox"
-										onDragEnter={alertDragDisable}
-									>
-										<img src={preview} alt={`Preview ${index + 1}`} />
-										{/* <input type="hidden" {...register(`images.${index}`)} /> */}
-										<S.DeleteButton onClick={() => onDeleteSubImage(index)}>
+			<>
+				<S.PreviewGroup>
+					<S.ToastMessageWrap isModalOpen={isModalOpen}>
+						<S.ToastMessage>
+							기존에 등록된 이미지는 순서 변경이 불가능합니다. <br />
+							순서 변경을 원하시면 이미지를 다시 등록해주세요.
+						</S.ToastMessage>
+					</S.ToastMessageWrap>
+					<input
+						type="file"
+						name="file"
+						id="file"
+						accept="image/*"
+						multiple
+						onChange={event => handleImageChange(event.target.files)}
+					/>
+					<label
+						htmlFor="file"
+						role="button"
+						className={isHighlight ? 'highlight' : ''}
+						onDragEnter={highlight}
+						onDragOver={highlight}
+						onDragLeave={unhighlight}
+						onDrop={handleDrop}
+					>
+						<img className="registerIcon" src={registerIcon} ref={ref} />
+					</label>
+					{mainImage && (
+						<>
+							{!isDesk && <p>기존 이미지</p>}
+							<div className="previewBoxWrap">
+								{mainImage && (
+									<div className="previewBox" onDragEnter={alertDragDisable}>
+										<img src={mainImage} alt="메인이미지" />
+										<S.DeleteButton onClick={onDeleteMainImage}>
 											<img src={deleteIcon} />
 										</S.DeleteButton>
 									</div>
-								))}
-						</div>
-					</>
-				)}
-				{imagePreviews.length > 0 && (
-					<DragDropContext onDragEnd={onDragEnd}>
-						<Droppable droppableId="droppable" direction="horizontal">
-							{provided => (
-								<>
-									{!isDesk && <p>신규 등록 이미지</p>}
-									<div
-										className="previewBoxWrap"
-										ref={provided.innerRef}
-										{...provided.droppableProps}
-									>
-										{imagePreviews.map((preview, index) => (
-											<Draggable
-												className="previewBox"
-												key={`Preview-${index}`}
-												draggableId={`Preview-${index}`}
-												index={index}
-											>
-												{provided => (
-													<div
-														ref={provided.innerRef}
-														{...provided.draggableProps}
-														{...provided.dragHandleProps}
-													>
-														<img
-															src={preview.img_url}
-															alt={`Preview ${index + 1}`}
-														/>
-														<input
-															type="hidden"
-															{...register(`images.${index}`)}
-														/>
-														<S.DeleteButton
-															onClick={() => onDeleteImage(index)}
+								)}
+								{subImageList.length > 0 &&
+									subImageList.map((preview, index) => (
+										<div
+											key={`img-${index}`}
+											className="previewBox"
+											onDragEnter={alertDragDisable}
+										>
+											<img src={preview} alt={`Preview ${index + 1}`} />
+											{/* <input type="hidden" {...register(`images.${index}`)} /> */}
+											<S.DeleteButton onClick={() => onDeleteSubImage(index)}>
+												<img src={deleteIcon} />
+											</S.DeleteButton>
+										</div>
+									))}
+							</div>
+						</>
+					)}
+					{imagePreviews.length > 0 && (
+						<DragDropContext onDragEnd={onDragEnd}>
+							<Droppable droppableId="droppable" direction="horizontal">
+								{provided => (
+									<>
+										{!isDesk && <p>신규 이미지</p>}
+										<div
+											className="previewBoxWrap"
+											ref={provided.innerRef}
+											{...provided.droppableProps}
+										>
+											{imagePreviews.map((preview, index) => (
+												<Draggable
+													className="previewBox"
+													key={`Preview-${index}`}
+													draggableId={`Preview-${index}`}
+													index={index}
+												>
+													{provided => (
+														<div
+															ref={provided.innerRef}
+															{...provided.draggableProps}
+															{...provided.dragHandleProps}
 														>
-															<img src={deleteIcon} />
-														</S.DeleteButton>
-													</div>
-												)}
-											</Draggable>
-										))}
-									</div>
-								</>
-							)}
-						</Droppable>
-					</DragDropContext>
+															<img
+																src={preview.img_url}
+																alt={`Preview ${index + 1}`}
+															/>
+															<input
+																type="hidden"
+																{...register(`images.${index}`)}
+															/>
+															<S.DeleteButton
+																onClick={() => onDeleteImage(index)}
+															>
+																<img src={deleteIcon} />
+															</S.DeleteButton>
+														</div>
+													)}
+												</Draggable>
+											))}
+										</div>
+									</>
+								)}
+							</Droppable>
+						</DragDropContext>
+					)}
+				</S.PreviewGroup>
+				<ul className="infoMessage">
+					<li>클릭 또는 이미지를 드래그하여 등록할 수 있습니다.</li>
+					<li>드래그하여 상품 이미지 순서를 변경할 수 있습니다.</li>
+				</ul>
+				{removeBgUrl && (
+					<S.RemoveBackgroundWrap>
+						<h3>대표 썸네일 미리보기</h3>
+						<S.FlexBox>
+							<S.ImageWrapper isRemoveBgLoading={isRemoveBgLoading}>
+								<img src={removeBgUrl} />
+							</S.ImageWrapper>
+							<S.TipWrapper>
+								<S.Tip>상품을 돋보이게 하는 TIP!</S.Tip>
+								<ul className="infoMessage">
+									<li>대표 사진의 배경을 제거하면 상품이 더 돋보여요</li>
+								</ul>
+								{isRemoveDone ? (
+									<div>배경 제거 완료! 🥳</div>
+								) : (
+									<Button
+										type="button"
+										label={'배경 제거하기'}
+										variant={'primary-outlined'}
+										onClick={removeBg}
+									/>
+								)}
+							</S.TipWrapper>
+						</S.FlexBox>
+					</S.RemoveBackgroundWrap>
 				)}
-			</S.PreviewGroup>
+			</>
 		)
 	},
 )
@@ -358,4 +417,100 @@ S.ToastMessage = styled.div`
 		theme.isDesktop || theme.isTabletAndLaptop
 			? theme.FONT_SIZE.medium
 			: theme.FONT_SIZE.small};
+`
+
+S.RemoveBackgroundWrap = styled.div`
+	margin-top: 20px;
+	border: 1px solid ${({ theme }) => theme.PALETTE.gray[500]};
+	border-radius: 10px;
+	padding: 20px;
+
+	& > h3 {
+		margin: 0 0 16px;
+		font-size: 16px;
+	}
+`
+
+S.FlexBox = styled.div`
+	display: flex;
+	flex-direction: ${({ theme }) =>
+		theme.isDesktop || theme.isTabletAndLaptop ? 'row' : 'column'};
+	justify-content: ${({ theme }) =>
+		theme.isDesktop || theme.isTabletAndLaptop ? 'space-around' : 'center'};
+	align-items: ${({ theme }) =>
+		theme.isDesktop || theme.isTabletAndLaptop ? 'flex-start' : 'center'};
+	width: 100%;
+	gap: 20px;
+`
+
+S.TipWrapper = styled.div`
+	display: flex;
+	flex-direction: column;
+	align-items: ${({ theme }) =>
+		theme.isDesktop || theme.isTabletAndLaptop ? 'flex-start' : 'center'};
+`
+
+S.Tip = styled.h3`
+	font-size: 16px;
+`
+
+S.ImageWrapper = styled.div`
+	position: relative;
+	width: 100%;
+	max-width: ${({ theme }) =>
+		theme.isDesktop || theme.isTabletAndLaptop
+			? '250px'
+			: `${theme.isTablet ? '50vw' : '70vw'}`};
+	aspect-ratio: 1 / 1;
+	border-radius: 10px;
+
+	&:before {
+		display: ${({ isRemoveBgLoading }) =>
+			isRemoveBgLoading ? 'block' : 'none'};
+		content: '';
+		position: absolute;
+		z-index: 10;
+		inset: 0;
+		background: rgba(255, 255, 255, 0.4);
+	}
+
+	&:after {
+		display: ${({ isRemoveBgLoading }) =>
+			isRemoveBgLoading ? 'block' : 'none'};
+		content: '';
+		position: absolute;
+		z-index: 20;
+		top: 50%;
+		left: 50%;
+		margin-top: -21px;
+		margin-left: -21px;
+		border-radius: 50%;
+		text-indent: -9999em;
+		width: 42px;
+		height: 42px;
+		border-width: 5px;
+		border-style: solid;
+		border-color: rgb(230, 233, 238) rgb(230, 233, 238) rgb(230, 233, 238)
+			rgb(0, 157, 145);
+		animation: 1.1s linear 0s infinite normal none running rotate;
+	}
+
+	@keyframes rotate {
+		0% {
+			transform: rotate(0deg);
+		}
+		100% {
+			transform: rotate(360deg);
+		}
+	}
+
+	img {
+		position: absolute;
+		top: 0;
+		left: 0;
+		width: 100%;
+		height: 100%;
+		object-fit: cover;
+		border-radius: 10px;
+	}
 `

--- a/src/components/ui/organisms/DeFormImagePreviewGroup/DeFormImagePreviewGroup.jsx
+++ b/src/components/ui/organisms/DeFormImagePreviewGroup/DeFormImagePreviewGroup.jsx
@@ -23,6 +23,7 @@ const DeFormImagePreviewGroup = forwardRef(
 			setImageFileList,
 			removeBgUrl,
 			setRemoveBgUrl,
+			type,
 		},
 		ref,
 	) => {
@@ -126,6 +127,7 @@ const DeFormImagePreviewGroup = forwardRef(
 
 		// 썸네일 미리보기
 		useEffect(() => {
+			if (type === 'review') return
 			if (!detail && imagePreviews.length > 0) {
 				setRemoveBgUrl(imagePreviews[0].img_url)
 				setIsRemoveDone(false)
@@ -246,7 +248,7 @@ const DeFormImagePreviewGroup = forwardRef(
 					<S.RemoveBackgroundWrap>
 						<h3>대표 썸네일 미리보기</h3>
 						<S.FlexBox>
-							<S.ImageWrapper isRemoveBgLoading={isRemoveBgLoading}>
+							<S.ImageWrapper isremovebgloading={isRemoveBgLoading.toString()}>
 								<img src={removeBgUrl} />
 							</S.ImageWrapper>
 							<S.TipWrapper>
@@ -397,12 +399,12 @@ S.DeleteButton = styled.div`
 
 S.ToastMessageWrap = styled.div`
 	display: ${({ ismodalopen }) => (ismodalopen === 'true' ? 'flex' : 'none')};
-	position: absolute;
+	position: fixed;
 	top: ${({ theme }) =>
-		theme.isDesktop || theme.isTabletAndLaptop ? '-30px' : '10em'};
+		theme.isDesktop || theme.isTabletAndLaptop ? '30px' : '10em'};
 	left: 0;
 	right: 0;
-	z-index: 11;
+	z-index: 999;
 	align-items: center;
 	justify-content: center;
 `
@@ -465,8 +467,8 @@ S.ImageWrapper = styled.div`
 	border-radius: 10px;
 
 	&:before {
-		display: ${({ isRemoveBgLoading }) =>
-			isRemoveBgLoading ? 'block' : 'none'};
+		display: ${({ isremovebgloading }) =>
+			isremovebgloading === 'true' ? 'block' : 'none'};
 		content: '';
 		position: absolute;
 		z-index: 10;
@@ -475,8 +477,8 @@ S.ImageWrapper = styled.div`
 	}
 
 	&:after {
-		display: ${({ isRemoveBgLoading }) =>
-			isRemoveBgLoading ? 'block' : 'none'};
+		display: ${({ isremovebgloading }) =>
+			isremovebgloading === 'true' ? 'block' : 'none'};
 		content: '';
 		position: absolute;
 		z-index: 20;

--- a/src/components/ui/organisms/MainFooter/MainFooter.jsx
+++ b/src/components/ui/organisms/MainFooter/MainFooter.jsx
@@ -20,7 +20,7 @@ const MainFooter = props => {
 							xmlns="http://www.w3.org/2000/svg"
 							viewBox="0 24 150 28"
 							preserveAspectRatio="none"
-							shape-rendering="auto"
+							shapeRendering="auto"
 						>
 							<path
 								x="48"


### PR DESCRIPTION
### 요약 (Summary)

- 물품 등록 시 배경 제거 기능 추가

### 바뀐 점 (Changes)

- 물품 등록 시 [배경 제거하기] 버튼을 누르면 라이브러리를 이용해 배경이 제거되는 코드를 추가했습니다.
- 물품 등록 시 지역 초기값 역삼동 하드코딩 -> 사용자 지역값으로 변경 (`useMypageApi.useGetinfo()`)
- 푸터에서 오류메세지 나던 부분 수정
  - 속성명 오타 수정
- 물품 등록 페이지에 오류메세지 나던 부분을 수정했습니다.
  - props에 lower case 전달 이슈
  - mui Select 태그 value에 null값 들어가서 오류메세지 나오던 부분 수정
  - Select 태그에 사용안하는 useRef 삭제
- 리뷰 작성 페이지 수정
  - 물품 이미지 등록폼 같이 사용하고 있어서 같이 수정했습니다.
  - 물품등록과 리뷰 구분값이 필요해서 props를 추가했습니다.
  - toast메세지가 안나오던건 css 위치속성 때문이었고 수정완료했습니다.

### 특이사항 (Optional)

- `@imgly/background-removal^1.0.6` 라이브러리 추가 (배경 제거 라이브러리)
- 수정 시에는 배경 제거 안합니다. (물품 등록 시에만 가능)

### Screenshots (Optional)

![Aug-11-2023 00-41-15](https://github.com/KIT-Frontend-Team2/Paradise/assets/11881721/b39c1da7-6284-4fdb-9676-80b938b75681)

