### PR TITLE
💄style : 디테일 페이지 css 변경

### DIFF
--- a/src/components/ui/organisms/DeImgSection/DeImgSection.jsx
+++ b/src/components/ui/organisms/DeImgSection/DeImgSection.jsx
@@ -51,7 +51,7 @@ S.LeftSection = styled.div`
 
 S.ImgBoxSticky = styled.div`
 	position: sticky;
-	top: 0;
+	top: 180px;
 `
 
 S.TitleImg = styled.div`

--- a/src/hooks/service/useViewList.service.js
+++ b/src/hooks/service/useViewList.service.js
@@ -4,6 +4,7 @@ import { queryClient } from '../../App'
 import viewListAxios from '../../apis/service/viewlist.api'
 import API_KEY from '../../consts/ApiKey'
 import { ERROR_MESSAGE, NETWORK } from '../../consts/api'
+import toastMessage from "../../utils/toast-message";
 
 const useViewListApi = {
 	useGetViewList: () => {
@@ -24,7 +25,7 @@ const useViewListApi = {
 			() => viewListAxios.postRecentProduct(productId),
 			{
 				onError: (err, newProduct, context) => {
-					alert(ERROR_MESSAGE)
+					toastMessage.error(ERROR_MESSAGE)
 					queryClient.setQueryData([API_KEY.VIEWLIST], context.previousProduct)
 				},
 				onSettled: () => queryClient.invalidateQueries([API_KEY.VIEWLIST]),
@@ -38,7 +39,7 @@ const useViewListApi = {
 			() => viewListAxios.deleteRecentProduct(productId),
 			{
 				onError: (err, newProduct, context) => {
-					alert(ERROR_MESSAGE)
+					toastMessage.error(ERROR_MESSAGE)
 					queryClient.setQueryData([API_KEY.VIEWLIST], context.previousProduct)
 				},
 				onSettled: () => queryClient.invalidateQueries([API_KEY.VIEWLIST]),

--- a/src/hooks/service/useViewList.service.js
+++ b/src/hooks/service/useViewList.service.js
@@ -4,7 +4,7 @@ import { queryClient } from '../../App'
 import viewListAxios from '../../apis/service/viewlist.api'
 import API_KEY from '../../consts/ApiKey'
 import { ERROR_MESSAGE, NETWORK } from '../../consts/api'
-import toastMessage from "../../utils/toast-message";
+import toastMessage from '../../utils/toast-message'
 
 const useViewListApi = {
 	useGetViewList: () => {


### PR DESCRIPTION
### 요약 (Summary)

- 디테일 페이지 sticky를 좀 더 자연스럽게 내려오게 하기 위해서 css를 변경하였습니다.

### 바뀐 점 (Changes)

- 디테일 페이지 sticky를 좀 더 자연스럽게 내려오게 하기 위해서 css를 변경하였습니다.


### 특이사항 (Optional)

- 기존의 최근 게시물의 error 표시를 toast 메세지로 변경하였습니다.

### Screenshots (Optional)

- 
![image](https://github.com/KIT-Frontend-Team2/Paradise/assets/115636461/0dab9811-50e8-4a58-bb12-4421ee5990c0)
