### PR TITLE
 💄style : 채팅창 css 수정

### DIFF
--- a/src/components/modal/Side/SideBar.jsx
+++ b/src/components/modal/Side/SideBar.jsx
@@ -39,6 +39,8 @@ S.SideBarBanner = styled.div`
 	margin-top: 216px;
 `
 S.SideBarChat = styled.div`
+	display: ${({ theme }) =>
+		theme.isDesktop || theme.isTabletAndLaptop ? 'block' : 'none'};
 	z-index: 100;
 	bottom: 10%;
 	position: fixed;

--- a/src/components/modal/chat/Chat.jsx
+++ b/src/components/modal/chat/Chat.jsx
@@ -80,15 +80,17 @@ S.ChatContainer = styled.div`
 	display: flex;
 	flex-direction: column;
 	position: fixed;
-	right: 16px;
+	right: ${({ theme }) =>
+		theme.isDesktop || theme.isTabletAndLaptop ? '16px' : '0'};
 	bottom: 0;
-	width: 600px;
-	height: 700px;
+	width: ${({ theme }) =>
+		theme.isDesktop || theme.isTabletAndLaptop ? '600px' : '100%'};
+	height: ${({ theme }) =>
+		theme.isDesktop || theme.isTabletAndLaptop ? '700px' : '100%'};
 
 	background-color: white;
-	border: 1px solid #eaeaea;
 	box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
-	z-index: 999;
+	z-index: 1200;
 `
 
 S.ChatListContent = styled.div`

--- a/src/components/modal/chat/ChatHeader.jsx
+++ b/src/components/modal/chat/ChatHeader.jsx
@@ -19,6 +19,7 @@ const ChatHeader = ({ layout, setLayout }) => {
 				display: 'flex',
 				justifyContent: 'center',
 				backgroundColor: '#009d91',
+				boxShadow: 'none',
 			}}
 		>
 			<Toolbar>
@@ -28,7 +29,7 @@ const ChatHeader = ({ layout, setLayout }) => {
 						aria-label="back"
 						onClick={() => setLayout(true)}
 					>
-						<ArrowBackIosIcon sx={{ color: '#fff', fontSize: '12px' }} />
+						<ArrowBackIosIcon sx={{ color: '#fff', fontSize: '16px' }} />
 					</IconButton>
 				)}
 				<Typography

--- a/src/components/modal/chat/ChatInput.jsx
+++ b/src/components/modal/chat/ChatInput.jsx
@@ -54,7 +54,7 @@ export default ChatInput
 export const S = {}
 
 S.Form = styled.form`
-	border-top: 1px solid #999999;
+	border-top: 1px solid ${({ theme }) => theme.PALETTE.gray[400]};
 	width: 100%;
 	height: 100px;
 	padding-top: 8px;

--- a/src/components/modal/chat/ChatMessage.jsx
+++ b/src/components/modal/chat/ChatMessage.jsx
@@ -91,13 +91,15 @@ S.MessageTime = styled.span`
 	grid-column: 1;
 	font-size: 12px;
 	color: #999;
+	min-width: 70px;
 `
 
 S.MessageText = styled.div`
-	padding: 0.5rem;
-	background-color: ${({ $issender }) => ($issender ? '#009D91' : '#ddd')};
+	padding: 0.5rem 1rem;
+	background-color: ${({ $issender, theme }) =>
+		$issender ? theme.PALETTE.primary[100] : theme.PALETTE.white};
 	border-radius: ${({ $issender }) =>
-		$issender ? '10px 0 10px 10px' : '0 10px 10px 10px'};
+		$issender ? '20px 0 20px 20px' : '0 20px 20px 20px'};
 	color: ${({ $issender }) => ($issender ? '#fff' : '#333')};
 `
 S.UnreadIndicator = styled.div`

--- a/src/components/modal/chat/ChatProductCard.jsx
+++ b/src/components/modal/chat/ChatProductCard.jsx
@@ -84,7 +84,9 @@ S.Container = styled.div`
 	position: fixed;
 	display: flex;
 	align-items: center;
-	width: ${({ collapsed }) => (collapsed === 'true' ? '550px' : '550px')};
+	width: ${({ theme }) =>
+		theme.isDesktop || theme.isTabletAndLaptop ? '550px' : 'calc(100% - 54px)'};
+	min-width: 280px;
 	height: ${({ collapsed }) => (collapsed === 'true' ? '20px' : '100px')};
 	border: 1px solid #dddddd;
 	border-radius: 6px;

--- a/src/components/modal/chat/Chating.jsx
+++ b/src/components/modal/chat/Chating.jsx
@@ -169,10 +169,12 @@ S.ChatInputContent = styled.div`
 
 S.MeesageContent = styled.div`
 	width: 100%;
-	height: calc(
-		700px - ${({ collapsed }) => (collapsed === 'true' ? '280px' : '320px')}
-	);
+	height: ${({ theme, collapsed }) =>
+		theme.isDesktop || theme.isTabletAndLaptop
+			? `calc( 700px - ${collapsed === 'true' ? '260px' : '320px'});`
+			: `calc(100vh - ${collapsed === 'true' ? '260px' : '320px'});`};
 
+	background-color: ${({ theme }) => theme.PALETTE.gray[100]};
 	overflow-y: auto;
 	padding-top: ${({ collapsed }) => (collapsed === 'true' ? '100px' : '160px')};
 `

--- a/src/components/ui/organisms/HeaderMobile/HeaderMobile.jsx
+++ b/src/components/ui/organisms/HeaderMobile/HeaderMobile.jsx
@@ -25,7 +25,14 @@ const HeaderMobile = () => {
 	}
 	return (
 		<>
-			<AppBar sx={{ position: 'fixed', backgroundColor: '#fff' }}>
+			<AppBar
+				sx={{
+					position: 'fixed',
+					backgroundColor: '#fff',
+					boxShadow: 'none',
+					borderBottom: '1px solid #ddd',
+				}}
+			>
 				<Toolbar>
 					<S.LogoBox>
 						<img src={headerlogo} alt="logo" />


### PR DESCRIPTION
### 요약 (Summary)

- 채팅창 css 수정

### 바뀐 점 (Changes)

- 채팅창의 css를 시안에 맞게 수정했습니다 (pc, mobile)


### 특이사항 (Optional)

- isTablet 사이즈부터 가로 100%로 차게 바꿨습니다.

### Screenshots (Optional)

![image](https://github.com/KIT-Frontend-Team2/Paradise/assets/11881721/8a8d36ca-3546-45ed-b6db-de5fcb7991bd)


![image](https://github.com/KIT-Frontend-Team2/Paradise/assets/11881721/7aa0b0a6-d727-4a74-ac45-b21bcb72d59f)
