### PR TITLE
 📝fix : 채팅창 .이 왼쪽에 찍히는 오류 수정

### DIFF
--- a/src/components/modal/chat/ChatMessage.jsx
+++ b/src/components/modal/chat/ChatMessage.jsx
@@ -48,7 +48,6 @@ S.MessageContainer = styled.div`
 	grid-template-columns: ${({ $issender }) => ($issender ? '1fr' : '40px 1fr')};
 	gap: 3px;
 	width: 100%;
-	direction: ${({ $issender }) => ($issender ? 'rtl' : 'ltr')};
 `
 
 S.AvatarContainer = styled.div`
@@ -74,6 +73,7 @@ S.MessageBox = styled.div`
 	align-items: end;
 	padding-right: ${({ issender }) => (issender ? 0 : '10px')};
 	padding-bottom: 10px;
+	flex-direction: ${({ $issender }) => ($issender ? 'row-reverse' : 'row')};
 `
 
 S.MetaInfo = styled.div`
@@ -91,7 +91,7 @@ S.MessageTime = styled.span`
 	grid-column: 1;
 	font-size: 12px;
 	color: #999;
-	min-width: 70px;
+	min-width: 60px;
 `
 
 S.MessageText = styled.div`


### PR DESCRIPTION
### 요약 (Summary)

- 채팅 메세지 '안녕하세요.'가 채팅창에서 '.안녕하세요'로 찍히는 오류 수정

### 바뀐 점 (Changes)
 
- css 속성을 direction:rtl 이 아닌 flex-direction: row-reverse로 css 변경


### 특이사항 (Optional)

- direction: rtl은 글자를 오른쪽에서 왼쪽으로 읽는 특정 국가에서 사용하는 UI를 구성할 때 쓰는 속성인 것 같습니다. div 끼리의 순서를 변경하고 싶을 땐 flex-direction: row-reverse로 하면 됩니다!

### Screenshots (Optional)


<img width="451" alt="image" src="https://github.com/KIT-Frontend-Team2/Paradise/assets/11881721/0d4b753d-da18-448b-aa41-9a09df080756">
